### PR TITLE
Issues/1445 reduce memory footprint

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -155,7 +155,7 @@ public class TestFactoryTestDescriptor extends TestMethodTestDescriptor implemen
 		}
 		if (dynamicDescendantFilter.test(uniqueId)) {
 			JupiterTestDescriptor descriptor = descriptorCreator.get();
-			parent.addChild(descriptor);
+			descriptor.setParent(parent);
 			return Optional.of(descriptor);
 		}
 		return Optional.empty();

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -135,7 +135,7 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor implem
 	}
 
 	private void execute(DynamicTestExecutor dynamicTestExecutor, TestDescriptor testDescriptor) {
-		addChild(testDescriptor);
+		testDescriptor.setParent(this);
 		dynamicTestExecutor.execute(testDescriptor);
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
@@ -11,7 +11,6 @@
 package org.junit.jupiter.engine;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -97,7 +96,7 @@ class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests {
 	}
 
 	@Test
-	void parentChildRelationshipIsEstablished() {
+	void parentRelationshipIsEstablished() {
 		LauncherDiscoveryRequest request = request().selectors(
 			selectMethod(MyTestTemplateTestCase.class, "templateWithSingleRegisteredExtension")).build();
 
@@ -107,7 +106,6 @@ class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests {
 			container("templateWithSingleRegisteredExtension"));
 		TestDescriptor invocationDescriptor = findTestDescriptor(executionResults, test("test-template-invocation:#1"));
 		assertThat(invocationDescriptor.getParent()).hasValue(templateMethodDescriptor);
-		assertThat(templateMethodDescriptor.getChildren()).isEqualTo(singleton(invocationDescriptor));
 	}
 
 	@Test

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
@@ -89,8 +89,7 @@ public class UniqueId implements Cloneable, Serializable {
 	private transient SoftReference<String> toString;
 
 	private UniqueId(UniqueIdFormat uniqueIdFormat, Segment segment) {
-		this.uniqueIdFormat = uniqueIdFormat;
-		this.segments = singletonList(segment);
+		this(uniqueIdFormat, singletonList(segment));
 	}
 
 	/**
@@ -101,8 +100,8 @@ public class UniqueId implements Cloneable, Serializable {
 	 * to the list instance that they pass into this constructor.
 	 */
 	UniqueId(UniqueIdFormat uniqueIdFormat, List<Segment> segments) {
-		this.uniqueIdFormat = uniqueIdFormat;
-		this.segments = unmodifiableList(segments);
+		this.uniqueIdFormat = uniqueIdFormat == UniqueIdFormat.getDefault() ? null : uniqueIdFormat;
+		this.segments = segments;
 	}
 
 	final Optional<Segment> getRoot() {
@@ -123,7 +122,7 @@ public class UniqueId implements Cloneable, Serializable {
 	 * {@code UniqueId}.
 	 */
 	public final List<Segment> getSegments() {
-		return this.segments;
+		return unmodifiableList(this.segments);
 	}
 
 	/**
@@ -157,7 +156,8 @@ public class UniqueId implements Cloneable, Serializable {
 	@API(status = STABLE, since = "1.1")
 	public final UniqueId append(Segment segment) {
 		Preconditions.notNull(segment, "segment must not be null");
-		List<Segment> baseSegments = new ArrayList<>(this.segments);
+		List<Segment> baseSegments = new ArrayList<>(this.segments.size() + 1);
+		baseSegments.addAll(segments);
 		baseSegments.add(segment);
 		return new UniqueId(this.uniqueIdFormat, baseSegments);
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
@@ -15,6 +15,7 @@ import static java.util.Collections.unmodifiableList;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.io.Serializable;
+import java.lang.ref.SoftReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -85,7 +86,7 @@ public class UniqueId implements Cloneable, Serializable {
 	// lazily computed
 	private transient int hashCode;
 	// lazily computed
-	private transient String toString;
+	private transient SoftReference<String> toString;
 
 	private UniqueId(UniqueIdFormat uniqueIdFormat, Segment segment) {
 		this.uniqueIdFormat = uniqueIdFormat;
@@ -250,9 +251,11 @@ public class UniqueId implements Cloneable, Serializable {
 	 */
 	@Override
 	public String toString() {
-		String s = this.toString;
-		if (s == null) {
-			s = this.uniqueIdFormat.format(this);
+		SoftReference<String> s = this.toString;
+		String value = s == null ? null : s.get();
+		if (value == null) {
+			UniqueIdFormat format = this.uniqueIdFormat == null ? UniqueIdFormat.getDefault() : this.uniqueIdFormat;
+			value = format.format(this);
 			// this is a benign race like String#hash
 			// we potentially read and write values from multiple threads
 			// without a happens-before relationship
@@ -260,9 +263,9 @@ public class UniqueId implements Cloneable, Serializable {
 			// that were valid at one point, either null or the toString value
 			// so we might end up not seeing a value that a different thread
 			// has computed or multiple threads writing the same value
-			this.toString = s;
+			this.toString = new SoftReference<>(value);
 		}
-		return s;
+		return value;
 	}
 
 	/**

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
@@ -91,9 +91,20 @@ public final class TestIdentifier implements Serializable {
 		this.parentId = parentId;
 		this.displayName = displayName;
 		this.source = source;
-		this.tags = unmodifiableSet(new LinkedHashSet<>(tags));
+		this.tags = copyOf(tags);
 		this.type = type;
 		this.legacyReportingName = legacyReportingName;
+	}
+
+	private Set<TestTag> copyOf(Set<TestTag> tags) {
+		switch (tags.size()) {
+			case 0:
+				return emptySet();
+			case 1:
+				return singleton(getOnlyElement(tags));
+			default:
+				return new LinkedHashSet<>(tags);
+		}
 	}
 
 	/**

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TestIdentifierTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TestIdentifierTests.java
@@ -56,11 +56,13 @@ class TestIdentifierTests {
 
 	@Test
 	void serialization() throws Exception {
+		var parentId = UniqueId.forEngine("engine");
+		var uniqueId = parentId.append("child", "child");
 		var identifier = serializeAndDeserialize(//
-			new TestIdentifier("uniqueId", "displayName", ClassSource.from(TestIdentifierTests.class),
-				Set.of(TestTag.create("aTag")), TestDescriptor.Type.TEST, "parentId", "reportingName"));
+			new TestIdentifier(uniqueId, "displayName", ClassSource.from(TestIdentifierTests.class),
+				Set.of(TestTag.create("aTag")), TestDescriptor.Type.TEST, parentId, "reportingName"));
 
-		assertEquals("uniqueId", identifier.getUniqueId());
+		assertEquals(uniqueId.toString(), identifier.getUniqueId());
 		assertEquals("displayName", identifier.getDisplayName());
 		assertEquals("reportingName", identifier.getLegacyReportingName());
 		assertThat(identifier.getSource()).contains(ClassSource.from(TestIdentifierTests.class));
@@ -68,7 +70,7 @@ class TestIdentifierTests {
 		assertEquals(TestDescriptor.Type.TEST, identifier.getType());
 		assertTrue(identifier.isTest());
 		assertFalse(identifier.isContainer());
-		assertThat(identifier.getParentId()).contains("parentId");
+		assertThat(identifier.getParentId()).contains(parentId.toString());
 	}
 
 }


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
